### PR TITLE
Add a Logger class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(SOURCES
   "binary_reader.h"
   "binary_reader.cpp"
+  "logger.h"
+  "logger.cpp"
 )
 
 find_package(Sanitizers)

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,0 +1,21 @@
+#include "logger.h"
+#include <fmt/format.h>
+
+bool Logger::Enabled = false;
+
+static void StandardOutputLogCallback(const std::string& message)
+{
+  fmt::print(message);
+}
+
+Logger::Logger(LogCallback callback) : callback_(callback)
+{
+  if (callback_ == nullptr)
+    callback_ = StandardOutputLogCallback;
+}
+
+void Logger::Write(const std::string& message)
+{
+  if (Enabled)
+    callback_(message);
+}

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+class Logger
+{
+public:
+  typedef void (*LogCallback)(const std::string&);
+  Logger(LogCallback callback);
+
+  static bool Enabled;
+
+  void Write(const std::string& message);
+
+private:
+  LogCallback callback_;
+};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
   "binary_reader_test.cpp"
+  "logger_test.cpp"
 )
 
 find_package(Sanitizers)

--- a/test/logger_test.cpp
+++ b/test/logger_test.cpp
@@ -1,0 +1,32 @@
+#include "catch.hpp"
+#include <string>
+
+#include "logger.h"
+
+std::string actualMessage;
+
+static void TestLogCallback(const std::string& message)
+{
+  actualMessage = message;
+}
+
+TEST_CASE("Logger")
+{
+  Logger logger(TestLogCallback);
+  Logger::Enabled = true;
+  actualMessage.clear();
+
+  SECTION("Can log a message")
+  {
+    const char* expectedMessage = "the clocks were striking thirteen";
+    logger.Write(expectedMessage);
+    REQUIRE(actualMessage == expectedMessage);
+  }
+
+  SECTION("Can be disabled")
+  {
+    Logger::Enabled = false;
+    logger.Write("this message should not be logged");
+    REQUIRE(actualMessage.empty());
+  }
+}

--- a/tools/tidy
+++ b/tools/tidy
@@ -8,5 +8,4 @@ else
   FILES="$1"
 fi
 echo Checking $FILES
-clang-tidy $FILES -config='' -- -std=c++11 -Ithirdparty/catch/include -Ithirdparty/gsl -Ithirdparty/benchmark/include -Isrc
-
+clang-tidy $FILES -config='' -- -std=c++11  -Ithirdparty/catch/include -Ithirdparty/gsl -Ithirdparty/benchmark/include -Ithirdparty/fmt/include -Isrc


### PR DESCRIPTION
The Logger can be enabled and disabled at runtime. It allows a callback
to be provided which will accept a message to log. The default callback
writes the message to standard output.