### PR TITLE
Make the logger static and compile time

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,3 +31,8 @@ else()
   target_compile_options(${LIB_NAME} PRIVATE "-pedantic")
 endif()
 
+option(ENABLE_LOGGING "Enable logging" OFF)
+if(ENABLE_LOGGING)
+  add_definitions(-DENABLE_LOGGING)
+endif(ENABLE_LOGGING)
+

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,21 +1,13 @@
 #include "logger.h"
 #include <fmt/format.h>
 
-bool Logger::Enabled = false;
-
 static void StandardOutputLogCallback(const std::string& message)
 {
-  fmt::print(message);
+  fmt::print("{}\n", message);
 }
 
-Logger::Logger(LogCallback callback) : callback_(callback)
-{
-  if (callback_ == nullptr)
-    callback_ = StandardOutputLogCallback;
-}
+Logger::LogCallback Logger::Callback = StandardOutputLogCallback;
 
-void Logger::Write(const std::string& message)
-{
-  if (Enabled)
-    callback_(message);
-}
+void Logger::SetCallback(LogCallback callback) { Callback = callback; }
+
+void Logger::Write(const std::string& message) { Callback(message); }

--- a/src/logger.h
+++ b/src/logger.h
@@ -2,16 +2,20 @@
 
 #include <string>
 
+#if defined(ENABLE_LOGGING)
+#define LOG_WRITE(message) Logger::Write(message)
+#else
+#define LOG_WRITE(message)
+#endif
+
 class Logger
 {
 public:
   using LogCallback = void (*)(const std::string&);
-  explicit Logger(LogCallback callback);
+  static void SetCallback(LogCallback callback);
 
-  static bool Enabled;
-
-  void Write(const std::string& message);
+  static void Write(const std::string& message);
 
 private:
-  LogCallback callback_;
+  static LogCallback Callback;
 };

--- a/test/logger_test.cpp
+++ b/test/logger_test.cpp
@@ -12,21 +12,13 @@ static void TestLogCallback(const std::string& message)
 
 TEST_CASE("Logger")
 {
-  Logger logger(TestLogCallback);
-  Logger::Enabled = true;
+  Logger::SetCallback(TestLogCallback);
   actualMessage.clear();
 
   SECTION("Can log a message")
   {
     const char* expectedMessage = "the clocks were striking thirteen";
-    logger.Write(expectedMessage);
+    Logger::Write(expectedMessage);
     REQUIRE(actualMessage == expectedMessage);
-  }
-
-  SECTION("Can be disabled")
-  {
-    Logger::Enabled = false;
-    logger.Write("this message should not be logged");
-    REQUIRE(actualMessage.empty());
   }
 }

--- a/tools/build-debug
+++ b/tools/build-debug
@@ -15,6 +15,8 @@ fi
 if [ -z "$CXX" ]; then
   export CXX=clang++
 fi
+# Use this line to build with logging enabled
+#cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_LOGGING=ON ../.. -GNinja
 cmake -DCMAKE_BUILD_TYPE=Debug ../.. -GNinja
 ninja
 ./test/tests

--- a/tools/build-release
+++ b/tools/build-release
@@ -16,6 +16,8 @@ if [ -z "$CXX" ]; then
   echo "CXX is not set, using clang by default"
   export CXX=clang++
 fi
+# Use this line to build with logging enabled
+#cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LOGGING=ON ../.. -GNinja
 cmake -DCMAKE_BUILD_TYPE=Release ../.. -GNinja
 ninja
 ./test/tests

--- a/tools/build-win32-debug.bat
+++ b/tools/build-win32-debug.bat
@@ -8,6 +8,8 @@ if not exist "win32" mkdir win32
 
 cd win32
 
+rem Use this line to build with logging enabled
+rem cmake ..\.. -DENABLE_LOGGING=ON -G "Visual Studio 15 2017" || exit /b 1
 cmake ..\.. -G "Visual Studio 15 2017" || exit /b 1
 
 msbuild /nologo /verbosity:quiet /p:Configuration=Debug binarily.sln || exit /b 1

--- a/tools/build-win32-release.bat
+++ b/tools/build-win32-release.bat
@@ -8,6 +8,8 @@ if not exist "win32" mkdir win32
 
 cd win32
 
+rem Use this line to build with logging enabled
+rem cmake ..\.. -DENABLE_LOGGING=ON -G "Visual Studio 15 2017" || exit /b 1
 cmake ..\.. -G "Visual Studio 15 2017" || exit /b 1
 
 msbuild /nologo /verbosity:quiet /p:Configuration=Release binarily.sln || exit /b 1

--- a/tools/build-win64-debug.bat
+++ b/tools/build-win64-debug.bat
@@ -8,6 +8,8 @@ if not exist "win64" mkdir win64
 
 cd win64
 
+rem Use this line to build with logging enabled
+rem cmake ..\.. -DENABLE_LOGGING=ON -G "Visual Studio 15 2017 Win64" || exit /b 1
 cmake ..\.. -G "Visual Studio 15 2017 Win64" || exit /b 1
 
 msbuild /nologo /verbosity:quiet /p:Configuration=Debug binarily.sln || exit /b 1

--- a/tools/build-win64-release.bat
+++ b/tools/build-win64-release.bat
@@ -8,6 +8,8 @@ if not exist "win64" mkdir win64
 
 cd win64
 
+rem Use this line to build with logging enabled
+rem cmake ..\.. -DENABLE_LOGGING=ON -G "Visual Studio 15 2017 Win64" || exit /b 1
 cmake ..\.. -G "Visual Studio 15 2017 Win64" || exit /b 1
 
 msbuild /nologo /verbosity:quiet /p:Configuration=Release binarily.sln || exit /b 1


### PR DESCRIPTION
The logger will now be a compile time option that cannot be enabled or
disabled at runtime, but instead can be enabled or disabled only at
compile time.