### PR TITLE
Add readers for ELF32 and ELF64

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,13 @@
 set(SOURCES
   "binary_reader.h"
   "binary_reader.cpp"
+  "binary_type.h"
+  "elf_reader.h"
+  "elf_reader.cpp"
+  "elf32_reader.h"
+  "elf32_reader.cpp"
+  "elf64_reader.h"
+  "elf64_reader.cpp"
   "logger.h"
   "logger.cpp"
   "type_detector.h"

--- a/src/binary_type.h
+++ b/src/binary_type.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace binarily
+{
+
+enum BinaryType
+{
+  UnknownBinary,
+  ELF64,
+  ELF32
+};
+
+} // namespace binarily

--- a/src/elf32_reader.cpp
+++ b/src/elf32_reader.cpp
@@ -1,0 +1,12 @@
+#include "elf32_reader.h"
+#include "elf_reader.h"
+
+namespace binarily
+{
+
+bool Elf32Reader::Is(const BinaryReader& reader) const
+{
+  return ElfReader::ElfTypeFor(reader) == ELF32;
+}
+
+} // namespace binarily

--- a/src/elf32_reader.h
+++ b/src/elf32_reader.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace binarily
+{
+
+class BinaryReader;
+
+class Elf32Reader
+{
+public:
+  bool Is(const BinaryReader& reader) const;
+};
+
+} // namespace binarily

--- a/src/elf64_reader.cpp
+++ b/src/elf64_reader.cpp
@@ -1,0 +1,12 @@
+#include "elf64_reader.h"
+#include "elf_reader.h"
+
+namespace binarily
+{
+
+bool Elf64Reader::Is(const BinaryReader& reader) const
+{
+  return ElfReader::ElfTypeFor(reader) == ELF64;
+}
+
+} // namespace binarily

--- a/src/elf64_reader.h
+++ b/src/elf64_reader.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace binarily
+{
+
+class BinaryReader;
+
+class Elf64Reader
+{
+public:
+  bool Is(const BinaryReader& reader) const;
+};
+
+} // namespace binarily

--- a/src/elf_reader.cpp
+++ b/src/elf_reader.cpp
@@ -1,0 +1,50 @@
+#include "elf_reader.h"
+#include "binary_reader.h"
+#include "logger.h"
+
+namespace binarily
+{
+
+BinaryType ElfReader::ElfTypeFor(const BinaryReader& binaryReader)
+{
+  std::array<uint8_t, 4> header{};
+  auto bytesRead = binaryReader.ReadBytes(header);
+  if (bytesRead == 4)
+  {
+    LOG("Read 4 bytes of the file header");
+    const std::array<uint8_t, 4> elfHeader{{0x7F, 0x45, 0x4c, 0x46}};
+    if (header == elfHeader)
+    {
+      LOG("This looks like an ELF binary");
+      const uint8_t bitness_32 = 1;
+      const uint8_t bitness_64 = 2;
+      uint8_t bitness = 0;
+      if (binaryReader.ReadByte(bitness))
+      {
+        if (bitness == bitness_32)
+        {
+          LOG("This is a 32-bit ELF binary");
+          return ELF32;
+        }
+
+        if (bitness == bitness_64)
+        {
+          LOG("This is a 64-bit ELF binary");
+          return ELF64;
+        }
+
+        LOGF("Invalid bitness byte value '{}', this is not an ELF binary",
+             bitness);
+      }
+      else
+      {
+        LOG("Unable to read the fifth byte of the file to determine bitness");
+        LOG("This must not be a valid ELF binary");
+      }
+    }
+  }
+
+  return UnknownBinary;
+}
+
+} // namespace binarily

--- a/src/elf_reader.h
+++ b/src/elf_reader.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "type_detector.h"
+
+namespace binarily
+{
+
+class BinaryReader;
+
+class ElfReader
+{
+public:
+  static BinaryType ElfTypeFor(const BinaryReader& binaryReader);
+};
+
+} // namespace binarily

--- a/src/type_detector.cpp
+++ b/src/type_detector.cpp
@@ -7,53 +7,23 @@
 namespace binarily
 {
 
-TypeDetector::TypeDetector(const BinaryReader& binaryReader)
-    : type_(UnknownBinary)
+TypeDetector::TypeDetector(BinaryReader& binaryReader) : type_(UnknownBinary)
 {
   assert(binaryReader.Exists());
-  type_ = CheckForELF(binaryReader);
+  type_ = TypeFor(binaryReader);
 }
 
 BinaryType TypeDetector::Type() const { return type_; }
 
-BinaryType TypeDetector::CheckForELF(const BinaryReader& binaryReader)
+BinaryType TypeDetector::TypeFor(BinaryReader& binaryReader)
 {
-  std::array<uint8_t, 4> header{};
-  auto bytesRead = binaryReader.ReadBytes(header);
-  if (bytesRead == 4)
-  {
-    LOG("Read 4 bytes of the file header");
-    const std::array<uint8_t, 4> elfHeader{{0x7F, 0x45, 0x4c, 0x46}};
-    if (header == elfHeader)
-    {
-      LOG("This looks like an ELF binary");
-      const uint8_t bitness_32 = 1;
-      const uint8_t bitness_64 = 2;
-      uint8_t bitness = 0;
-      if (binaryReader.ReadByte(bitness))
-      {
-        if (bitness == bitness_32)
-        {
-          LOG("This is a 32-bit ELF binary");
-          return ELF32;
-        }
+  if (elf32Reader_.Is(binaryReader))
+    return ELF32;
 
-        if (bitness == bitness_64)
-        {
-          LOG("This is a 64-bit ELF binary");
-          return ELF64;
-        }
+  binaryReader.Reset();
 
-        LOGF("Invalid bitness byte value '{}', this is not an ELF binary",
-             bitness);
-      }
-      else
-      {
-        LOG("Unable to read the fifth byte of the file to determine bitness");
-        LOG("This must not be a valid ELF binary");
-      }
-    }
-  }
+  if (elf64Reader_.Is(binaryReader))
+    return ELF64;
 
   return UnknownBinary;
 }

--- a/src/type_detector.h
+++ b/src/type_detector.h
@@ -1,28 +1,28 @@
 #pragma once
 
+#include "binary_type.h"
+#include "elf32_reader.h"
+#include "elf64_reader.h"
+
 namespace binarily
 {
 
 class BinaryReader;
 
-enum BinaryType
-{
-  UnknownBinary,
-  ELF64,
-  ELF32
-};
-
 class TypeDetector
 {
 public:
-  explicit TypeDetector(const BinaryReader& binaryReader);
+  explicit TypeDetector(BinaryReader& binaryReader);
 
   BinaryType Type() const;
 
 private:
   BinaryType type_;
 
-  BinaryType CheckForELF(const BinaryReader& binaryReader);
+  Elf32Reader elf32Reader_;
+  Elf64Reader elf64Reader_;
+
+  BinaryType TypeFor(BinaryReader& binaryReader);
 };
 
 } // namespace binarily

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(SOURCES
   "binary_reader_test.cpp"
+  "elf_reader_test.cpp"
+  "elf32_reader_test.cpp"
+  "elf64_reader_test.cpp"
   "logger_test.cpp"
   "type_detector_test.cpp"
 )

--- a/test/elf32_reader_test.cpp
+++ b/test/elf32_reader_test.cpp
@@ -1,0 +1,31 @@
+#include "catch.hpp"
+
+#include "binary_reader.h"
+#include "elf32_reader.h"
+
+using namespace binarily;
+
+static bool IsElf32(const char* filePath)
+{
+  BinaryReader reader(filePath);
+  Elf32Reader elf32Reader;
+  return elf32Reader.Is(reader);
+}
+
+TEST_CASE("ELF 32-bit Reader")
+{
+  SECTION("An unspecified file is not ELF 32-bit")
+  {
+    REQUIRE(!IsElf32("../../test/data/unknown_binary"));
+  }
+
+  SECTION("A 64-bit ELF file is not ELF 32-bit")
+  {
+    REQUIRE(!IsElf32("../../test/data/simple_elf64"));
+  }
+
+  SECTION("A 32-bit ELF file is correctly identified")
+  {
+    REQUIRE(IsElf32("../../test/data/simple_elf32"));
+  }
+}

--- a/test/elf64_reader_test.cpp
+++ b/test/elf64_reader_test.cpp
@@ -1,0 +1,31 @@
+#include "catch.hpp"
+
+#include "binary_reader.h"
+#include "elf64_reader.h"
+
+using namespace binarily;
+
+static bool IsElf64(const char* filePath)
+{
+  BinaryReader reader(filePath);
+  Elf64Reader elf64Reader;
+  return elf64Reader.Is(reader);
+}
+
+TEST_CASE("ELF 64-bit Reader")
+{
+  SECTION("An unspecified file is not ELF 64-bit")
+  {
+    REQUIRE(!IsElf64("../../test/data/unknown_binary"));
+  }
+
+  SECTION("A 32-bit ELF file is not ELF 64-bit")
+  {
+    REQUIRE(!IsElf64("../../test/data/simple_elf32"));
+  }
+
+  SECTION("A 64-bit ELF file is correctly identified")
+  {
+    REQUIRE(IsElf64("../../test/data/simple_elf64"));
+  }
+}

--- a/test/elf_reader_test.cpp
+++ b/test/elf_reader_test.cpp
@@ -1,0 +1,47 @@
+#include "catch.hpp"
+
+#include "binary_reader.h"
+#include "elf_reader.h"
+#include "type_detector.h"
+
+using namespace binarily;
+
+static BinaryType GetTypeFor(const char* filePath)
+{
+  BinaryReader reader(filePath);
+  return ElfReader::ElfTypeFor(reader);
+}
+
+TEST_CASE("ELF Reader")
+{
+  SECTION("An unspecified file is an unknown type")
+  {
+    REQUIRE(GetTypeFor("../../test/data/unknown_binary") == UnknownBinary);
+  }
+
+  SECTION("An one byte file is an unknown type")
+  {
+    REQUIRE(GetTypeFor("../../test/data/one_byte_file") == UnknownBinary);
+  }
+
+  SECTION("Can detect a 64-bit ELF file")
+  {
+    REQUIRE(GetTypeFor("../../test/data/simple_elf64") == ELF64);
+  }
+
+  SECTION("Can detect a 32-bit ELF file")
+  {
+    REQUIRE(GetTypeFor("../../test/data/simple_elf32") == ELF32);
+  }
+
+  SECTION("Can detect a file with an ELF header but no bitness flag")
+  {
+    REQUIRE(GetTypeFor("../../test/data/elf_without_bitness") == UnknownBinary);
+  }
+
+  SECTION("Can detect a file with an ELF header but wrong bitness flag")
+  {
+    REQUIRE(GetTypeFor("../../test/data/elf_with_wrong_bitness") ==
+            UnknownBinary);
+  }
+}


### PR DESCRIPTION
As we need to read farther into ELF files, split the ELF reading code
into two classes. Common code will go in the `ElfReader` class. This
also simplified the `TypeDetector` class, so it just dispatches to
readers to determine the file type.