### PR TITLE
Rename BinaryReader to be BinaryFileReader

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(SOURCES
-  "binary_reader_bench.cpp"
+  "binary_file_reader_bench.cpp"
 )
 
 set(LIB_NAME ${PROJECT_NAME}_lib)

--- a/bench/binary_file_reader_bench.cpp
+++ b/bench/binary_file_reader_bench.cpp
@@ -1,4 +1,4 @@
-#include "binary_reader.h"
+#include "binary_file_reader.h"
 #include <array>
 #include <benchmark/benchmark.h>
 
@@ -6,7 +6,7 @@ using namespace binarily;
 
 static void ReadEightBytes(benchmark::State& state)
 {
-  BinaryReader reader("../../../test/data/simple.wasm");
+  BinaryFileReader reader("../../../test/data/simple.wasm");
   for (auto _ : state)
   {
     uint8_t buffer[8];
@@ -22,7 +22,7 @@ static void ReadWholeFile(benchmark::State& state)
 {
   for (auto _ : state)
   {
-    BinaryReader reader("../../../test/data/simple.wasm");
+    BinaryFileReader reader("../../../test/data/simple.wasm");
     std::array<uint8_t, 115> buffer{};
     reader.ReadBytes(buffer);
     benchmark::DoNotOptimize(buffer);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
   "binary_reader.h"
-  "binary_reader.cpp"
+  "binary_file_reader.h"
+  "binary_file_reader.cpp"
   "binary_type.h"
   "elf_common.h"
   "elf_common.cpp"

--- a/src/binary_file_reader.cpp
+++ b/src/binary_file_reader.cpp
@@ -1,11 +1,11 @@
-#include "binary_reader.h"
+#include "binary_file_reader.h"
 #include "logger.h"
 #include <cassert>
 
 namespace binarily
 {
 
-BinaryReader::BinaryReader(const char* file_path)
+BinaryFileReader::BinaryFileReader(const char* file_path)
     : buffer_(), current_(bufferSize_), bufferUsedSize_(0)
 {
   LOGF("Attempting to open file '{}'", file_path);
@@ -13,15 +13,15 @@ BinaryReader::BinaryReader(const char* file_path)
   LOGF("File open {}: {}", file_ ? "succeeded" : "failed", (void*)file_);
 }
 
-BinaryReader::~BinaryReader()
+BinaryFileReader::~BinaryFileReader()
 {
   if (file_ != nullptr)
     fclose(file_);
 }
 
-bool BinaryReader::Exists() const { return file_ != nullptr; }
+bool BinaryFileReader::Exists() const { return file_ != nullptr; }
 
-bool BinaryReader::ReadByte(uint8_t& value) const
+bool BinaryFileReader::ReadByte(uint8_t& value) const
 {
   if (current_ >= bufferUsedSize_)
   {
@@ -34,7 +34,7 @@ bool BinaryReader::ReadByte(uint8_t& value) const
   return true;
 }
 
-int BinaryReader::ReadBytes(gsl::span<uint8_t> buffer) const
+int BinaryFileReader::ReadBytes(gsl::span<uint8_t> buffer) const
 {
   int bytes = 0;
   for (auto& value : buffer)
@@ -49,7 +49,7 @@ int BinaryReader::ReadBytes(gsl::span<uint8_t> buffer) const
   return bytes;
 }
 
-void BinaryReader::Reset()
+void BinaryFileReader::Reset()
 {
   int error = fseek(file_, 0, SEEK_SET);
   current_ = bufferSize_;

--- a/src/binary_file_reader.h
+++ b/src/binary_file_reader.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <gsl>
+
+#include "binary_reader.h"
+
+namespace binarily
+{
+
+class BinaryFileReader : public BinaryReader
+{
+public:
+  explicit BinaryFileReader(const char* file_path);
+  ~BinaryFileReader();
+
+  // Don't allow copy, assignment, or move.
+  BinaryFileReader(const BinaryFileReader&) = delete;
+  BinaryFileReader& operator=(const BinaryFileReader&) = delete;
+  BinaryFileReader(BinaryFileReader&&) = delete;
+  BinaryFileReader& operator=(BinaryFileReader&&) = delete;
+
+  bool Exists() const final;
+
+  bool ReadByte(uint8_t& value) const final;
+  int ReadBytes(gsl::span<uint8_t> buffer) const final;
+  void Reset() final;
+
+private:
+  FILE* file_;
+  static const int bufferSize_ = 128;
+  mutable std::array<uint8_t, bufferSize_> buffer_;
+  mutable size_t current_;
+  mutable size_t bufferUsedSize_;
+};
+
+} // namespace binarily

--- a/src/binary_reader.h
+++ b/src/binary_reader.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <array>
 #include <cstdint>
-#include <cstdio>
 #include <gsl>
 
 namespace binarily
@@ -11,27 +9,11 @@ namespace binarily
 class BinaryReader
 {
 public:
-  explicit BinaryReader(const char* file_path);
-  ~BinaryReader();
+  virtual bool Exists() const = 0;
 
-  // Don't allow copy, assignment, or move.
-  BinaryReader(const BinaryReader&) = delete;            // copy constructor
-  BinaryReader& operator=(const BinaryReader&) = delete; // copy assignment
-  BinaryReader(BinaryReader&&) = delete;                 // move constructor
-  BinaryReader& operator=(BinaryReader&&) = delete;      // move assignment
-
-  bool Exists() const;
-
-  bool ReadByte(uint8_t& value) const;
-  int ReadBytes(gsl::span<uint8_t> buffer) const;
-  void Reset();
-
-private:
-  FILE* file_;
-  static const int bufferSize_ = 128;
-  mutable std::array<uint8_t, bufferSize_> buffer_;
-  mutable size_t current_;
-  mutable size_t bufferUsedSize_;
+  virtual bool ReadByte(uint8_t& value) const = 0;
+  virtual int ReadBytes(gsl::span<uint8_t> buffer) const = 0;
+  virtual void Reset() = 0;
 };
 
 } // namespace binarily

--- a/src/elf32_file_header.cpp
+++ b/src/elf32_file_header.cpp
@@ -7,7 +7,7 @@
 namespace binarily
 {
 
-Elf32FileHeader::Elf32FileHeader(const BinaryReader& reader) : header_()
+Elf32FileHeader::Elf32FileHeader(const BinaryReader* reader) : header_()
 {
   header_ = ElfCommon::ReadFileHeader(reader);
 }

--- a/src/elf32_file_header.h
+++ b/src/elf32_file_header.h
@@ -14,7 +14,7 @@ class BinaryReader;
 class Elf32FileHeader : public FileHeader
 {
 public:
-  explicit Elf32FileHeader(const BinaryReader& reader);
+  explicit Elf32FileHeader(const BinaryReader* reader);
 
   Bitness GetBitness() const override;
   Endianness GetEndianness() const override;

--- a/src/elf32_reader.cpp
+++ b/src/elf32_reader.cpp
@@ -4,7 +4,7 @@
 namespace binarily
 {
 
-bool Elf32Reader::Is(const BinaryReader& reader)
+bool Elf32Reader::Is(const BinaryReader* reader)
 {
   return ElfReader::ElfTypeFor(reader) == ELF32;
 }

--- a/src/elf32_reader.h
+++ b/src/elf32_reader.h
@@ -10,7 +10,7 @@ class BinaryReader;
 class Elf32Reader
 {
 public:
-  static bool Is(const BinaryReader& reader);
+  static bool Is(const BinaryReader* reader);
 };
 
 } // namespace binarily

--- a/src/elf64_file_header.cpp
+++ b/src/elf64_file_header.cpp
@@ -8,7 +8,7 @@
 namespace binarily
 {
 
-Elf64FileHeader::Elf64FileHeader(const BinaryReader& reader) : header_()
+Elf64FileHeader::Elf64FileHeader(const BinaryReader* reader) : header_()
 {
   header_ = ElfCommon::ReadFileHeader(reader);
 }

--- a/src/elf64_file_header.h
+++ b/src/elf64_file_header.h
@@ -14,7 +14,7 @@ class BinaryReader;
 class Elf64FileHeader : public FileHeader
 {
 public:
-  explicit Elf64FileHeader(const BinaryReader& reader);
+  explicit Elf64FileHeader(const BinaryReader* reader);
 
   Bitness GetBitness() const override;
   Endianness GetEndianness() const override;

--- a/src/elf64_reader.cpp
+++ b/src/elf64_reader.cpp
@@ -4,7 +4,7 @@
 namespace binarily
 {
 
-bool Elf64Reader::Is(const BinaryReader& reader)
+bool Elf64Reader::Is(const BinaryReader* reader)
 {
   return ElfReader::ElfTypeFor(reader) == ELF64;
 }

--- a/src/elf64_reader.h
+++ b/src/elf64_reader.h
@@ -8,7 +8,7 @@ class BinaryReader;
 class Elf64Reader
 {
 public:
-  static bool Is(const BinaryReader& reader);
+  static bool Is(const BinaryReader* reader);
 };
 
 } // namespace binarily

--- a/src/elf_common.cpp
+++ b/src/elf_common.cpp
@@ -6,11 +6,11 @@
 namespace binarily
 {
 
-Elf_Ehdr ElfCommon::ReadFileHeader(const BinaryReader& reader)
+Elf_Ehdr ElfCommon::ReadFileHeader(const BinaryReader* reader)
 {
   Elf_Ehdr header = {};
   std::array<uint8_t, sizeof(header)> buffer{};
-  int bytesRead = reader.ReadBytes(buffer);
+  int bytesRead = reader->ReadBytes(buffer);
   LOGF("Read {} bytes from header_ file of {} bytes expected", bytesRead,
        sizeof(header));
   std::memcpy(&header, buffer.data(), bytesRead);

--- a/src/elf_common.h
+++ b/src/elf_common.h
@@ -39,7 +39,7 @@ struct Elf_Ehdr // NOLINT
 
 struct ElfCommon
 {
-  static Elf_Ehdr ReadFileHeader(const BinaryReader& reader);
+  static Elf_Ehdr ReadFileHeader(const BinaryReader* reader);
   static Endianness GetEndianness(const Elf_Ehdr& header);
 };
 

--- a/src/elf_reader.cpp
+++ b/src/elf_reader.cpp
@@ -5,10 +5,10 @@
 namespace binarily
 {
 
-BinaryType ElfReader::ElfTypeFor(const BinaryReader& binaryReader)
+BinaryType ElfReader::ElfTypeFor(const BinaryReader* binaryReader)
 {
   std::array<uint8_t, 4> header{};
-  auto bytesRead = binaryReader.ReadBytes(header);
+  auto bytesRead = binaryReader->ReadBytes(header);
   if (bytesRead == 4)
   {
     LOG("Read 4 bytes of the file header");
@@ -19,7 +19,7 @@ BinaryType ElfReader::ElfTypeFor(const BinaryReader& binaryReader)
       const uint8_t bitness_32 = 1;
       const uint8_t bitness_64 = 2;
       uint8_t bitness = 0;
-      if (binaryReader.ReadByte(bitness))
+      if (binaryReader->ReadByte(bitness))
       {
         if (bitness == bitness_32)
         {

--- a/src/elf_reader.h
+++ b/src/elf_reader.h
@@ -10,7 +10,7 @@ class BinaryReader;
 class ElfReader
 {
 public:
-  static BinaryType ElfTypeFor(const BinaryReader& binaryReader);
+  static BinaryType ElfTypeFor(const BinaryReader* binaryReader);
 };
 
 } // namespace binarily

--- a/src/type_detector.cpp
+++ b/src/type_detector.cpp
@@ -7,20 +7,20 @@
 namespace binarily
 {
 
-TypeDetector::TypeDetector(BinaryReader& binaryReader) : type_(UnknownBinary)
+TypeDetector::TypeDetector(BinaryReader* binaryReader) : type_(UnknownBinary)
 {
-  assert(binaryReader.Exists());
+  assert(binaryReader->Exists());
   type_ = TypeFor(binaryReader);
 }
 
 BinaryType TypeDetector::Type() const { return type_; }
 
-BinaryType TypeDetector::TypeFor(BinaryReader& binaryReader)
+BinaryType TypeDetector::TypeFor(BinaryReader* binaryReader)
 {
   if (Elf32Reader::Is(binaryReader))
     return ELF32;
 
-  binaryReader.Reset();
+  binaryReader->Reset();
 
   if (Elf64Reader::Is(binaryReader))
     return ELF64;

--- a/src/type_detector.h
+++ b/src/type_detector.h
@@ -12,14 +12,14 @@ class BinaryReader;
 class TypeDetector
 {
 public:
-  explicit TypeDetector(BinaryReader& binaryReader);
+  explicit TypeDetector(BinaryReader* binaryReader);
 
   BinaryType Type() const;
 
 private:
   BinaryType type_;
 
-  static BinaryType TypeFor(BinaryReader& binaryReader);
+  static BinaryType TypeFor(BinaryReader* binaryReader);
 };
 
 } // namespace binarily

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(SOURCES
-  "binary_reader_test.cpp"
+  "binary_file_reader_test.cpp"
   "elf_reader_test.cpp"
   "elf32_file_header_test.cpp"
   "elf32_reader_test.cpp"

--- a/test/binary_file_reader_test.cpp
+++ b/test/binary_file_reader_test.cpp
@@ -3,13 +3,13 @@
 #include <array>
 #include <cstring>
 
-#include "binary_reader.h"
+#include "binary_file_reader.h"
 
 using namespace binarily;
 
 TEST_CASE("Binary Reader")
 {
-  BinaryReader reader("../../test/data/simple.wasm");
+  BinaryFileReader reader("../../test/data/simple.wasm");
 
   SECTION("Can read first byte from a file")
   {
@@ -118,6 +118,6 @@ TEST_CASE("Binary Reader")
 
 TEST_CASE("Can handle a missing file")
 {
-  BinaryReader reader("Does not exist");
+  BinaryFileReader reader("Does not exist");
   REQUIRE(!reader.Exists());
 }

--- a/test/elf32_file_header_test.cpp
+++ b/test/elf32_file_header_test.cpp
@@ -1,14 +1,14 @@
 #include "catch.hpp"
 
-#include "binary_reader.h"
+#include "binary_file_reader.h"
 #include "elf32_file_header.h"
 
 using namespace binarily;
 
 static Endianness GetEndiannessFor(const char* filePath)
 {
-  BinaryReader reader(filePath);
-  Elf32FileHeader header(reader);
+  BinaryFileReader reader(filePath);
+  Elf32FileHeader header(&reader);
   return header.GetEndianness();
 }
 
@@ -16,8 +16,8 @@ TEST_CASE("ELF32 File Header")
 {
   SECTION("Knows the proper bitness")
   {
-    BinaryReader reader("../../test/data/simple_elf32");
-    Elf32FileHeader header(reader);
+    BinaryFileReader reader("../../test/data/simple_elf32");
+    Elf32FileHeader header(&reader);
     REQUIRE(header.GetBitness() == ThirtyTwoBit);
   }
 

--- a/test/elf32_reader_test.cpp
+++ b/test/elf32_reader_test.cpp
@@ -1,14 +1,14 @@
 #include "catch.hpp"
 
-#include "binary_reader.h"
+#include "binary_file_reader.h"
 #include "elf32_reader.h"
 
 using namespace binarily;
 
 static bool IsElf32(const char* filePath)
 {
-  BinaryReader reader(filePath);
-  return Elf32Reader::Is(reader);
+  BinaryFileReader reader(filePath);
+  return Elf32Reader::Is(&reader);
 }
 
 TEST_CASE("ELF 32-bit Reader")

--- a/test/elf64_file_header_test.cpp
+++ b/test/elf64_file_header_test.cpp
@@ -1,14 +1,14 @@
 #include "catch.hpp"
 
-#include "binary_reader.h"
+#include "binary_file_reader.h"
 #include "elf64_file_header.h"
 
 using namespace binarily;
 
 static Endianness GetEndiannessFor(const char* filePath)
 {
-  BinaryReader reader(filePath);
-  Elf64FileHeader header(reader);
+  BinaryFileReader reader(filePath);
+  Elf64FileHeader header(&reader);
   return header.GetEndianness();
 }
 
@@ -16,8 +16,8 @@ TEST_CASE("ELF64 File Header")
 {
   SECTION("Knows the proper bitness")
   {
-    BinaryReader reader("../../test/data/simple_elf64");
-    Elf64FileHeader header(reader);
+    BinaryFileReader reader("../../test/data/simple_elf64");
+    Elf64FileHeader header(&reader);
     REQUIRE(header.GetBitness() == SixtyFourBit);
   }
 

--- a/test/elf64_reader_test.cpp
+++ b/test/elf64_reader_test.cpp
@@ -1,14 +1,14 @@
 #include "catch.hpp"
 
-#include "binary_reader.h"
+#include "binary_file_reader.h"
 #include "elf64_reader.h"
 
 using namespace binarily;
 
 static bool IsElf64(const char* filePath)
 {
-  BinaryReader reader(filePath);
-  return Elf64Reader::Is(reader);
+  BinaryFileReader reader(filePath);
+  return Elf64Reader::Is(&reader);
 }
 
 TEST_CASE("ELF 64-bit Reader")

--- a/test/elf_reader_test.cpp
+++ b/test/elf_reader_test.cpp
@@ -1,6 +1,6 @@
 #include "catch.hpp"
 
-#include "binary_reader.h"
+#include "binary_file_reader.h"
 #include "elf_reader.h"
 #include "type_detector.h"
 
@@ -8,8 +8,8 @@ using namespace binarily;
 
 static BinaryType GetTypeFor(const char* filePath)
 {
-  BinaryReader reader(filePath);
-  return ElfReader::ElfTypeFor(reader);
+  BinaryFileReader reader(filePath);
+  return ElfReader::ElfTypeFor(&reader);
 }
 
 TEST_CASE("ELF Reader")

--- a/test/type_detector_test.cpp
+++ b/test/type_detector_test.cpp
@@ -1,6 +1,6 @@
 #include "catch.hpp"
 
-#include "binary_reader.h"
+#include "binary_file_reader.h"
 #include "type_detector.h"
 
 using namespace binarily;
@@ -9,43 +9,43 @@ TEST_CASE("Type Detector")
 {
   SECTION("An unspecified file is an unknown type")
   {
-    BinaryReader reader("../../test/data/unknown_binary");
-    TypeDetector detector(reader);
+    BinaryFileReader reader("../../test/data/unknown_binary");
+    TypeDetector detector(&reader);
     REQUIRE(detector.Type() == UnknownBinary);
   }
 
   SECTION("An one byte file is an unknown type")
   {
-    BinaryReader reader("../../test/data/one_byte_file");
-    TypeDetector detector(reader);
+    BinaryFileReader reader("../../test/data/one_byte_file");
+    TypeDetector detector(&reader);
     REQUIRE(detector.Type() == UnknownBinary);
   }
 
   SECTION("Can detect a 64-bit ELF file")
   {
-    BinaryReader reader("../../test/data/simple_elf64");
-    TypeDetector detector(reader);
+    BinaryFileReader reader("../../test/data/simple_elf64");
+    TypeDetector detector(&reader);
     REQUIRE(detector.Type() == ELF64);
   }
 
   SECTION("Can detect a 32-bit ELF file")
   {
-    BinaryReader reader("../../test/data/simple_elf32");
-    TypeDetector detector(reader);
+    BinaryFileReader reader("../../test/data/simple_elf32");
+    TypeDetector detector(&reader);
     REQUIRE(detector.Type() == ELF32);
   }
 
   SECTION("Can detect a file with an ELF header but no bitness flag")
   {
-    BinaryReader reader("../../test/data/elf_without_bitness");
-    TypeDetector detector(reader);
+    BinaryFileReader reader("../../test/data/elf_without_bitness");
+    TypeDetector detector(&reader);
     REQUIRE(detector.Type() == UnknownBinary);
   }
 
   SECTION("Can detect a file with an ELF header but wrong bitness flag")
   {
-    BinaryReader reader("../../test/data/elf_with_wrong_bitness");
-    TypeDetector detector(reader);
+    BinaryFileReader reader("../../test/data/elf_with_wrong_bitness");
+    TypeDetector detector(&reader);
     REQUIRE(detector.Type() == UnknownBinary);
   }
 }


### PR DESCRIPTION
Introduce `BinaryReader` as an abstract base class, which
`BinaryFileReader` inherits from. Change the consumers of `BinaryReader`
to accept it via pointer.