### PR TITLE
Reset the binary reader for the header

### DIFF
--- a/src/elf_common.cpp
+++ b/src/elf_common.cpp
@@ -11,7 +11,7 @@ Elf_Ehdr ElfCommon::ReadFileHeader(const BinaryReader* reader)
   Elf_Ehdr header = {};
   std::array<uint8_t, sizeof(header)> buffer{};
   int bytesRead = reader->ReadBytes(buffer);
-  LOGF("Read {} bytes from header_ file of {} bytes expected", bytesRead,
+  LOGF("Read {} bytes from file header of {} bytes expected", bytesRead,
        sizeof(header));
   std::memcpy(&header, buffer.data(), bytesRead);
   return header;
@@ -19,6 +19,7 @@ Elf_Ehdr ElfCommon::ReadFileHeader(const BinaryReader* reader)
 
 Endianness ElfCommon::GetEndianness(const Elf_Ehdr& header)
 {
+  LOGF("Reading endianness {} from header", header.e_ident[EiData]);
   if (header.e_ident[EiData] == 1)
     return LittleEndian;
   if (header.e_ident[EiData] == 2)

--- a/src/file_data.cpp
+++ b/src/file_data.cpp
@@ -16,6 +16,7 @@ FileData FileData::Load(const uint8_t* buffer, int size)
 {
   BinaryBufferReader reader(buffer, size);
   TypeDetector detector(&reader);
+  reader.Reset();
   auto type = detector.Type();
   if (type == ELF32)
     return Elf32Reader::GetFileData(&reader);

--- a/test/file_data_test.cpp
+++ b/test/file_data_test.cpp
@@ -74,6 +74,8 @@ TEST_CASE("File Data")
     auto buffer = TestUtils::LoadFile("../../test/data/simple_elf32");
     auto fileData = FileData::Load(buffer.data(), buffer.size());
     REQUIRE(fileData.header.type == ELF32);
+    REQUIRE(fileData.header.bitness == ThirtyTwoBit);
+    REQUIRE(fileData.header.endianness == LittleEndian);
   }
 
   SECTION("Can load FileData for an ELF 64-bit binary")
@@ -81,6 +83,8 @@ TEST_CASE("File Data")
     auto buffer = TestUtils::LoadFile("../../test/data/simple_elf64");
     auto fileData = FileData::Load(buffer.data(), buffer.size());
     REQUIRE(fileData.header.type == ELF64);
+    REQUIRE(fileData.header.bitness == SixtyFourBit);
+    REQUIRE(fileData.header.endianness == LittleEndian);
   }
 
   SECTION("Can load FileData for an unkown binary")
@@ -88,5 +92,7 @@ TEST_CASE("File Data")
     auto buffer = TestUtils::LoadFile("../../test/data/unknown_binary");
     auto fileData = FileData::Load(buffer.data(), buffer.size());
     REQUIRE(fileData.header.type == UnknownBinary);
+    REQUIRE(fileData.header.bitness == UnknownBitness);
+    REQUIRE(fileData.header.endianness == UnknownEndian);
   }
 }


### PR DESCRIPTION
This allows the header data to be computed properly.
